### PR TITLE
N문 N답 API JWT 미들웨어 추가 + API 수정

### DIFF
--- a/config/baseResponse.js
+++ b/config/baseResponse.js
@@ -17,6 +17,8 @@ const baseResponse = {
     USER_USERID_NOT_EXIST : { "isSuccess": false, "code": 3001, "message": "해당 유저가 존재하지 않습니다." },
     USER_USERID_NOT_MATCH : {"isSuccess":false, "code":3002, "message":"user_id 값을 확인해주세요."},
     USER_NICKNAME_DUPLICATED : {"isSuccess":false, "code":3003, "message":"닉네임이 이미 존재합니다"},
+    USER_USERID_USERIDFROMJWT_NOT_MATCH : {"isSuccess":false, "code":3004, "message":"user_id와 userIdFromJWT가 일치하지 않습니다."},
+
 
     //스티커 관련 오류 4000번
     STICKER_STICKERID_NOT_EXIST : { "isSuccess": false, "code": 4000, "message": "해당 스티커가 존재하지 않습니다." },

--- a/src/app/user/userController.js
+++ b/src/app/user/userController.js
@@ -321,18 +321,29 @@ export const nqnaController = {
         
         try {
             const {user_id} = req.params; 
+            const {viewType} = req.body;
             //const type = req.query.type; //type으로 Host, visitor 구분 >>>> 일단 보류
             const userIdFromJWT = req.verifiedToken ? req.verifiedToken.user_id : null; // 토큰이 있을 때만 user_id를 가져오도록 수정
 
             if(user_id == userIdFromJWT){ //호스트 본인의 N문 N답 페이지일 때 (호스트 플로우)
-
-                const nQnA = await nqnaProvider.retrieveHostNQnA(user_id);
-                return res.status(200).json({
-                    isSuccess: true,
-                    code: 1000,
-                    message: "호스트 플로우 N문 N답 조회 성공",
-                    result: nQnA
-                });
+                if(viewType == "UnAnswered"){
+                    const nQnA = await nqnaProvider.retrieveHostQnA(user_id); 
+                    return res.status(200).json({
+                        isSuccess: true,
+                        code: 1000,
+                        message: "호스트 플로우 N문 N답 조회 성공 (답변 + 질문)",
+                        result: nQnA
+                    });
+                }
+                else if(viewType == "Answered"){
+                    const nQnA = await nqnaProvider.retrieveHostQ(user_id);
+                    return res.status(200).json({
+                        isSuccess: true,
+                        code: 1000,
+                        message: "호스트 플로우 N문 N답 조회 성공 (미답변 질문)",
+                        result: nQnA
+                    });
+                }
             }
             else{ //다른 호스트의 N문 N답 페이지일 때 (방문자 플로우) 
 

--- a/src/app/user/userDao.js
+++ b/src/app/user/userDao.js
@@ -202,14 +202,14 @@ export const nqnaDao = {
     },
 
     selectHostQ : async(connection,user_id)=>{ // 호스트 플로우 미답변 질문 조회
-        const selectHostNQnAQuery = `
+        const selectHostQQuery = `
             SELECT nQnA_id, question, question_type, question_hidden
             FROM nQnA
             ORDER BY question_created
             WHERE user_id = ?;
         `
-        const [selectHostNQnARow] = await connection.query(selectHostNQnAQuery,user_id);
-        return selectHostNQnARow;
+        const [selectHostQRow] = await connection.query(selectHostQQuery,user_id);
+        return selectHostQRow;
     },
 
     selectVisitorNQnA : async(connection,user_id)=>{ // 방문자 플로우 nQnA 전체 조회

--- a/src/app/user/userDao.js
+++ b/src/app/user/userDao.js
@@ -190,10 +190,22 @@ export const nqnaDao = {
         return selectNQnARow;
     },
 
-    selectHostNQnA : async(connection,user_id)=>{ // 호스트 플로우 nQnA 전체 조회
+    selectHostNQnA : async(connection,user_id)=>{ // 호스트 플로우 답변 + 질문 조회
         const selectHostNQnAQuery = `
-            SELECT nQnA_id, question, question_type, question_hidden, answer, answer_hidden, created_at
+            SELECT nQnA_id, question, question_type, question_hidden, answer, answer_hidden
             FROM nQnA
+            ORDER BY answer_created
+            WHERE user_id = ?;
+        `
+        const [selectHostNQnARow] = await connection.query(selectHostNQnAQuery,user_id);
+        return selectHostNQnARow;
+    },
+
+    selectHostQ : async(connection,user_id)=>{ // 호스트 플로우 미답변 질문 조회
+        const selectHostNQnAQuery = `
+            SELECT nQnA_id, question, question_type, question_hidden
+            FROM nQnA
+            ORDER BY question_created
             WHERE user_id = ?;
         `
         const [selectHostNQnARow] = await connection.query(selectHostNQnAQuery,user_id);
@@ -202,7 +214,7 @@ export const nqnaDao = {
 
     selectVisitorNQnA : async(connection,user_id)=>{ // 방문자 플로우 nQnA 전체 조회
         const selectVisitorNQnAQuery = `
-            SELECT nQnA_id, question, question_hidden, answer, answer_hidden, created_at
+            SELECT nQnA_id, question, question_hidden, answer, answer_hidden, question_created
             FROM nQnA
             WHERE user_id = ?;
         `

--- a/src/app/user/userProvider.js
+++ b/src/app/user/userProvider.js
@@ -146,10 +146,10 @@ export const nqnaProvider = { //n문n답
     retrieveHostQ : async(user_id) =>{ //호스트 플로우 미답변 질문 조회
         try{ 
             const connection = await pool.getConnection(async conn => conn);
-            const hostNQnAResult = await nqnaDao.selectHostQ(connection,user_id);
+            const hostQResult = await nqnaDao.selectHostQ(connection,user_id);
             connection.release();
     
-            return hostNQnAResult;
+            return hostQResult;
     
         }catch(err){
             console.error(err);        

--- a/src/app/user/userProvider.js
+++ b/src/app/user/userProvider.js
@@ -130,10 +130,23 @@ export const nqnaProvider = { //n문n답
         }
         },
 
-    retrieveHostNQnA : async(user_id) =>{ //호스트 플로우 nQnA 전체 조회
+    retrieveHostNQnA : async(user_id) =>{ //호스트 플로우 답변 + 질문 조회
         try{ 
             const connection = await pool.getConnection(async conn => conn);
             const hostNQnAResult = await nqnaDao.selectHostNQnA(connection,user_id);
+            connection.release();
+    
+            return hostNQnAResult;
+    
+        }catch(err){
+            console.error(err);        
+        }
+        },
+
+    retrieveHostQ : async(user_id) =>{ //호스트 플로우 미답변 질문 조회
+        try{ 
+            const connection = await pool.getConnection(async conn => conn);
+            const hostNQnAResult = await nqnaDao.selectHostQ(connection,user_id);
             connection.release();
     
             return hostNQnAResult;

--- a/src/app/user/userRoute.js
+++ b/src/app/user/userRoute.js
@@ -722,6 +722,12 @@ userRouter.get("/:user_id/nqna", jwtMiddleware, nqnaController.getnQnA); //N문 
  *      description: 사용자 ID
  *      schema:
  *        type: integer
+ *    - in: body
+ *      name: viewType
+ *      required: true
+ *      description: N문 N답 조회 type (미답변 질문만 or 답변 + 질문)
+ *      schema:
+ *        type: string
  *    responses:
  *      '200':
  *        description: 호스트 플로우 조회 성공

--- a/src/app/user/userRoute.js
+++ b/src/app/user/userRoute.js
@@ -598,6 +598,7 @@ userRouter.get(
 // nQnA 관련
 userRouter.post(
   "/:user_id/nqna/question/default",
+  jwtMiddleware,
   nqnaController.postDefaultQuestion
 ); //default 질문 등록 API
 /**
@@ -671,7 +672,7 @@ userRouter.post(
  *              message:
  *                  type: string
  */
-userRouter.patch("/:user_id/nqna/:nQnA_id/answer", nqnaController.postAnswer); //Host 답변 등록 + 수정 API
+userRouter.patch("/:user_id/nqna/:nQnA_id/answer", jwtMiddleware, nqnaController.postAnswer); //Host 답변 등록 + 수정 API
 /**
  * @swagger
  * paths:
@@ -781,6 +782,7 @@ userRouter.get("/:user_id/nqna", jwtMiddleware, nqnaController.getnQnA); //N문 
  */
 userRouter.patch(
   "/:user_id/nqna/:nQnA_id/question/hidden",
+  jwtMiddleware,
   nqnaController.patchQuestionHidden
 ); //질문 공개 여부 수정 API
 /**
@@ -818,6 +820,7 @@ userRouter.patch(
  */
 userRouter.patch(
   "/:user_id/nqna/:nQnA_id/answer/hidden",
+  jwtMiddleware,
   nqnaController.patchAnswerHidden
 ); //답변 공개 여부 수정 API
 /**
@@ -855,6 +858,7 @@ userRouter.patch(
  */
 userRouter.get(
   "/:user_id/nqna/question/emptyanswer",
+  jwtMiddleware,
   nqnaController.getEmptyAnswer
 ); //미답변 질문 개수 조회 API
 /**


### PR DESCRIPTION
- [x]  호스트 입장 API에 JWT 미들웨어 추가
- [x]  미답변 내역은 질문의 최신순, 질문 + 답변 내역은 답변의 최신순 조회로 수정
- [x]  n문n답 최신순 정렬된 데이터를 넘겨주도록 수정

소셜 로그인 인증 방식이 바뀌어서 jwt 토큰이 필요한 API 테스트를 못함.
소셜 로그인 url, redirect_uri 수정해야 함. 

